### PR TITLE
Fix Alpine build

### DIFF
--- a/.github/workflows/build-ffmpeg-macos.yml
+++ b/.github/workflows/build-ffmpeg-macos.yml
@@ -15,7 +15,8 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
-          brew install nasm pkg-config curl cmake automake openssl@1.1 fribidi fontconfig ninja
+          brew install nasm pkg-config automake openssl@1.1 fribidi fontconfig ninja
+          # brew install curl cmake
           curl -sL https://bootstrap.pypa.io/get-pip.py | python3
           pip3 install meson
       - uses: actions/checkout@v2

--- a/ffmpeg-compile/build-ffmpeg.sh
+++ b/ffmpeg-compile/build-ffmpeg.sh
@@ -133,8 +133,9 @@ if [[ "$HOSTTYPE" == x86_64 ]] ; then
    #
    # libvmaf
    #
-   DIR=$TMPDIR/vmaf; mkdir -p "$DIR"; cd "$DIR"
-   curl -sL https://github.com/Netflix/vmaf/archive/v${LIB_VMAF_VERSION}.tar.gz | tar xz --strip-components=1
+   DIR=$TMPDIR/vmaf; cd "$TMPDIR"
+   git clone -b v${LIB_VMAF_VERSION} https://github.com/Netflix/vmaf.git
+   cd $DIR
    meson setup libvmaf libvmaf/build --buildtype release --prefix="$PREFIX" --libdir "$PREFIX/lib"
    $sudo ninja -vC libvmaf/build install
    rm -fR "$DIR"

--- a/ffmpeg-compile/build-ffmpeg.sh
+++ b/ffmpeg-compile/build-ffmpeg.sh
@@ -137,7 +137,8 @@ if [[ "$HOSTTYPE" == x86_64 ]] ; then
    git clone -b v${LIB_VMAF_VERSION} https://github.com/Netflix/vmaf.git
    cd $DIR
    meson setup libvmaf libvmaf/build --buildtype release --prefix="$PREFIX" --libdir "$PREFIX/lib"
-   $sudo ninja -vC libvmaf/build include/vcs_version.h install
+   $sudo ninja -vC libvmaf/build include/vcs_version.h # on some system this is not generated automatically
+   $sudo ninja -vC libvmaf/build install
    rm -fR "$DIR"
 
    VMAF="--enable-libvmaf"

--- a/ffmpeg-compile/build-ffmpeg.sh
+++ b/ffmpeg-compile/build-ffmpeg.sh
@@ -137,7 +137,7 @@ if [[ "$HOSTTYPE" == x86_64 ]] ; then
    git clone -b v${LIB_VMAF_VERSION} https://github.com/Netflix/vmaf.git
    cd $DIR
    meson setup libvmaf libvmaf/build --buildtype release --prefix="$PREFIX" --libdir "$PREFIX/lib"
-   $sudo ninja -vC libvmaf/build install
+   $sudo ninja -vC libvmaf/build include/vcs_version.h install
    rm -fR "$DIR"
 
    VMAF="--enable-libvmaf"


### PR DESCRIPTION
Alpine uses a newer version of `ninja`.
This makes libvmaf fail, because if it can't produce `vcs_version.h` from `vcs_version.h.in`. The reason is that it expected to get a git tag from that folder. This info is not available if we download the tarball.